### PR TITLE
Adding lman and eval ice modifiers so they don't break syntax highlighting (fixes #5)

### DIFF
--- a/after/syntax/zsh.vim
+++ b/after/syntax/zsh.vim
@@ -78,6 +78,9 @@ syn region ZinitIceWithParam matchgroup=ZinitIce start=+\s\%(param\)"+ skip=+\\"
             \ contains=ZinitIceDoubleQuoteParam
 
 " added by the existing annexes
+syn region ZinitIceWithParam matchgroup=ZinitIce start=+\s\%(lman\|eval\)"+ skip=+\\"+ end=+"+ skipwhite contained
+            \ nextgroup=@ZinitLine,ZinitContinue
+            \ contains=ZinitIceDoubleQuoteParam
 syn region ZinitIceWithParam matchgroup=ZinitIce start=+\s\%(fbin\|lbin\|sbin\|gem\|node\|pip\|fmod\|fsrc\|ferc\)"+ skip=+\\"+ end=+"+ skipwhite contained
             \ nextgroup=@ZinitLine,ZinitContinue
             \ contains=ZinitIceDoubleQuoteParam
@@ -114,6 +117,9 @@ syn region ZinitIceWithParam matchgroup=ZinitIce start=+\s\%(param\)'+ skip=+\\'
             \ contains=ZinitIceSingleQuoteParam
 
 " added by the existing annexes
+syn region ZinitIceWithParam matchgroup=ZinitIce start=+\s\%(lman\|eval\)'+ skip=+\\'+ end=+'+ skipwhite contained
+            \ nextgroup=@ZinitLine,ZinitContinue
+            \ contains=ZinitIceSingleQuoteParam
 syn region ZinitIceWithParam matchgroup=ZinitIce start=+\s\%(fbin\|lbin\|sbin\|gem\|node\|pip\|fmod\|fsrc\|ferc\)'+ skip=+\\'+ end=+'+ skipwhite contained
             \ nextgroup=@ZinitLine,ZinitContinue
             \ contains=ZinitIceSingleQuoteParam
@@ -139,6 +145,10 @@ syn match ZinitIce '\s!\?\%(sh\|bash\|ksh\|csh\)\>'ms=s+1 skipwhite contained
 syn match ZinitIce '\s\%(id-as\|nocompile\|reset-prompt\|trackbinds\|aliases\|light-mode\)\>'ms=s+1 skipwhite contained
             \ nextgroup=@ZinitLine,ZinitContinue
 syn match ZinitIce '\s\%(is-snippet\)\>'ms=s+1 skipwhite contained
+            \ nextgroup=@ZinitLine,ZinitContinue
+syn match ZinitIce '\s\%(extract\)\>'ms=s+1 skipwhite contained
+            \ nextgroup=@ZinitLine,ZinitContinue
+syn match ZinitIce '\s\%(lman\|eval\)'ms=s+1 skipwhite contained
             \ nextgroup=@ZinitLine,ZinitContinue
 
 " ices that doens't take a param, from zinit packages


### PR DESCRIPTION
## Description
This adds lman and eval as recognized ice modifiers for zinit-vim-syntax

Fixes #5

## Motivation and Context <!--- What problem does it solve? -->

## Usage examples
n/a, this simply fixes broken syntax highlighting

## How Has This Been Tested?
...by editing my zinit config in vim

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [ what tests ] All new and existing tests passed.
- [ seriously, what test ] I have added tests to cover my changes.
- [ what documentation? ] I have updated the documentation accordingly.
- [x] I have made changes that should be incorporated into this project that are in line with this project's stated goals.